### PR TITLE
Add BUILD targets and fake_data flag to test CIFAR10-BNN example

### DIFF
--- a/tensorflow_probability/examples/BUILD
+++ b/tensorflow_probability/examples/BUILD
@@ -271,3 +271,34 @@ py_test(
         ":vq_vae",
     ],
 )
+
+py_binary(
+    name = "cifar10_bnn",
+    srcs = ["cifar10_bnn.py"],
+    main = "cifar10_bnn.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        # absl/flags dep,
+        # matplotlib dep,
+        # numpy dep,
+        # tensorflow dep,
+        "//tensorflow_probability",
+        "//tensorflow_probability/examples/models",
+    ],
+)
+
+py_test(
+    name = "cifar10_bnn_test",
+    size = "medium",
+    srcs = ["cifar10_bnn.py"],
+    args = [
+        "--fake_data",
+        "--epochs=1",
+        "--batch_size=5",
+    ],
+    main = "cifar10_bnn.py",
+    srcs_version = "PY2AND3",
+    deps = [
+        ":cifar10_bnn",
+    ],
+)

--- a/tensorflow_probability/examples/models/BUILD
+++ b/tensorflow_probability/examples/models/BUILD
@@ -1,0 +1,53 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+# Description:
+#   Models for CIFAR10 BNN example
+
+licenses(["notice"])  # Apache 2.0
+
+package(
+    default_visibility = [
+        "//tensorflow_probability:__subpackages__",
+    ],
+)
+
+exports_files(["LICENSE"])
+
+py_library(
+    name = "models",
+    srcs = ["__init__.py"],
+    deps = [
+        ":bayesian_resnet",
+        ":bayesian_vgg",
+    ],
+)
+
+py_library(
+    name = "bayesian_resnet",
+    srcs = ["bayesian_resnet.py"],
+    deps = [
+        # tensorflow dep,
+        "//tensorflow_probability",
+    ],
+)
+
+py_library(
+    name = "bayesian_vgg",
+    srcs = ["bayesian_vgg.py"],
+    deps = [
+        # tensorflow dep,
+        "//tensorflow_probability",
+    ],
+)

--- a/tensorflow_probability/examples/models/__init__.py
+++ b/tensorflow_probability/examples/models/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2018 The TensorFlow Probability Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================

--- a/tensorflow_probability/examples/models/bayesian_resnet.py
+++ b/tensorflow_probability/examples/models/bayesian_resnet.py
@@ -32,11 +32,11 @@ def bayesian_resnet(input_shape,
   Args:
     input_shape: A `tuple` indicating the Tensor shape.
     kernel_posterior_scale_mean: Python `int` number for the kernel
-      posterior's scale (log variance) mean. The smaller the mean the closer 
+      posterior's scale (log variance) mean. The smaller the mean the closer
       is the initialization to a deterministic network.
     kernel_posterior_scale_stddev: Python `float` number for the initial kernel
       posterior's scale stddev.
-      i.e. q(W|x) ~ N(mu, var), 
+      i.e. q(W|x) ~ N(mu, var),
            log_var ~ N(kernel_posterior_scale_mean, kernel_posterior_scale_stddev)
     kernel_posterior_scale_constraint: Python `float` number for the log value
       to constrain the log variance throughout training.

--- a/tensorflow_probability/examples/models/bayesian_vgg.py
+++ b/tensorflow_probability/examples/models/bayesian_vgg.py
@@ -32,11 +32,11 @@ def bayesian_vgg(input_shape,
   Args:
     input_shape: A `tuple` indicating the Tensor shape.
     kernel_posterior_scale_mean: Python `int` number for the kernel
-      posterior's scale (log variance) mean. The smaller the mean the closer 
+      posterior's scale (log variance) mean. The smaller the mean the closer
       is the initialization to a deterministic network.
     kernel_posterior_scale_stddev: Python `float` number for the initial kernel
       posterior's scale stddev.
-      i.e. q(W|x) ~ N(mu, var), 
+      i.e. q(W|x) ~ N(mu, var),
            log_var ~ N(kernel_posterior_scale_mean, kernel_posterior_scale_stddev)
     kernel_posterior_scale_constraint: Python `float` number for the log value
       to constrain the log variance throughout training.


### PR DESCRIPTION
Also clean up some trailing whitespaces.

Because the original example contribution (CIFAR10 BNN) by @jmzeng includes a new submodule under examples, we will need to add an `__init__.py` file, `BUILD` targets, and unit test with fake data, so that our internal continuous integration system can ensure the example is not broken by future changes to the code base.

This is the first example to use an examples submodule and, as written originally, was done using relative imports; this works for running the script directly with the python binary, but breaks when using bazel (as our internal CI systems will do). Thus, in order for it to work in all required environments, we need to refactor the imports, and add BUILD targets as described above.